### PR TITLE
Add GtkTrayIcon background patch

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = gtk3-mushrooms
 	pkgdesc = GTK3 patched for classic desktops like XFCE or MATE. Please see README.
 	pkgver = 3.22.30
-	pkgrel = 8
+	pkgrel = 9
 	url = https://github.com/TomaszGasior/gtk3-mushrooms
 	arch = x86_64
 	license = LGPL
@@ -65,6 +65,7 @@ pkgbase = gtk3-mushrooms
 	source = https://download.gnome.org/sources/gtk+/3.22/gtk+-3.22.30.tar.xz
 	source = upstream_transparent_window_bg_1._patch::https://github.com/GNOME/gtk/commit/2ce63a86ba689aa41eb47409c889c469497478b0.patch
 	source = upstream_transparent_window_bg_2._patch::https://github.com/GNOME/gtk/commit/01d1bc3c75fd0eff5665f5b9c690c5e1e6c65f13.patch
+	source = fixes__gtktrayicon-background._patch
 	source = settings.ini::https://git.archlinux.org/svntogit/packages.git/plain/trunk/settings.ini?h=packages/gtk3&id=fbcc57e8a97827926b6624bb8bc570f675c7188d
 	source = gtk-query-immodules-3.0.hook::https://git.archlinux.org/svntogit/packages.git/plain/trunk/gtk-query-immodules-3.0.hook?h=packages/gtk3&id=fbcc57e8a97827926b6624bb8bc570f675c7188d
 	sha256sums = 68b26360764a2ea7e057a2aaa29c6fdfe164b9987866e038d8d0188a025477fb
@@ -91,6 +92,7 @@ pkgbase = gtk3-mushrooms
 	sha256sums = a1a4a5c12703d4e1ccda28333b87ff462741dc365131fbc94c218ae81d9a6567
 	sha256sums = ceb95c0952ccd3ded84cd55a2386a33edac91597052b077d12fa4a3cc62a1612
 	sha256sums = 68e3ea59140ee565a146fff2db2d2e2ed99536bbad8ba818bee124325d516e01
+	sha256sums = a829e9ec0d49781958a5f210d4ac5f7d065f3de7e67b62946d7637c937c91b22
 	sha256sums = 01fc1d81dc82c4a052ac6e25bf9a04e7647267cc3017bc91f9ce3e63e5eb9202
 	sha256sums = de46e5514ff39a7a65e01e485e874775ab1c0ad20b8e94ada43f4a6af1370845
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ __arch_pkg_commit="fbcc57e8a97827926b6624bb8bc570f675c7188d"
 
 pkgname=gtk3-mushrooms
 pkgver=3.22.30
-pkgrel=8
+pkgrel=9
 pkgdesc="GTK3 patched for classic desktops like XFCE or MATE. Please see README."
 url="https://github.com/TomaszGasior/gtk3-mushrooms"
 conflicts=(gtk3 gtk3-print-backends)
@@ -61,6 +61,7 @@ source=(
 	# Temporary. Will be removed with next GTK3 release.
 	"upstream_transparent_window_bg_1._patch::https://github.com/GNOME/gtk/commit/2ce63a86ba689aa41eb47409c889c469497478b0.patch"
 	"upstream_transparent_window_bg_2._patch::https://github.com/GNOME/gtk/commit/01d1bc3c75fd0eff5665f5b9c690c5e1e6c65f13.patch"
+	"fixes__gtktrayicon-background._patch"
 
 	# Arch Linux package files.
 	"settings.ini::https://git.archlinux.org/svntogit/packages.git/plain/trunk/settings.ini?h=packages/gtk3&id=$__arch_pkg_commit"
@@ -91,6 +92,7 @@ sha256sums=(
 	"a1a4a5c12703d4e1ccda28333b87ff462741dc365131fbc94c218ae81d9a6567"
 	"ceb95c0952ccd3ded84cd55a2386a33edac91597052b077d12fa4a3cc62a1612"
 	"68e3ea59140ee565a146fff2db2d2e2ed99536bbad8ba818bee124325d516e01"
+	"a829e9ec0d49781958a5f210d4ac5f7d065f3de7e67b62946d7637c937c91b22"
 	"01fc1d81dc82c4a052ac6e25bf9a04e7647267cc3017bc91f9ce3e63e5eb9202"
 	"de46e5514ff39a7a65e01e485e874775ab1c0ad20b8e94ada43f4a6af1370845"
 )
@@ -146,6 +148,7 @@ prepare()
 	# Temporary. Will be removed with next GTK3 release.
 	patch -p 1 -i "$srcdir/upstream_transparent_window_bg_1._patch"
 	patch -p 1 -i "$srcdir/upstream_transparent_window_bg_2._patch"
+	patch -p 1 -i "$srcdir/fixes__gtktrayicon-background._patch"
 
 	NOCONFIGURE=1 ./autogen.sh
 }

--- a/fixes__gtktrayicon-background._patch
+++ b/fixes__gtktrayicon-background._patch
@@ -1,0 +1,53 @@
+--- a/gtk/deprecated/gtktrayicon-x11.c
++++ b/gtk/deprecated/gtktrayicon-x11.c
+@@ -37,6 +37,8 @@
+ #include "gtktypebuiltins.h"
+ #include "gtkrender.h"
+ 
++#include "gdkinternals.h"
++
+ #define SYSTEM_TRAY_REQUEST_DOCK    0
+ #define SYSTEM_TRAY_BEGIN_MESSAGE   1
+ #define SYSTEM_TRAY_CANCEL_MESSAGE  2
+@@ -966,6 +968,7 @@
+   else
+     {
+       /* Set a parent-relative background pixmap */
++      window->is_tray = TRUE;
+       gdk_window_set_background_pattern (window, NULL);
+     }
+ G_GNUC_END_IGNORE_DEPRECATIONS
+--- a/gdk/gdkinternals.h
++++ b/gdk/gdkinternals.h
+@@ -330,6 +330,7 @@
+   guint modal_hint : 1;
+   guint composited : 1;
+   guint has_alpha_background : 1;
++  guint is_tray : 1;
+ 
+   guint destroyed : 2;
+ 
+--- a/gdk/x11/gdkwindow-x11.c
++++ b/gdk/x11/gdkwindow-x11.c
+@@ -2982,6 +2982,21 @@
+ 
+   if (pattern == NULL)
+     {
++      if (window->is_tray)
++        {
++          GdkWindow *parent;
++
++          /* X throws BadMatch if the parent has a different depth when
++           * using ParentRelative */
++          parent = gdk_window_get_parent (window);
++          if (parent && window->depth == parent->depth)
++            {
++              XSetWindowBackgroundPixmap (GDK_WINDOW_XDISPLAY (window),
++                                          GDK_WINDOW_XID (window), ParentRelative);
++              return;
++            }
++        }
++
+       XSetWindowBackgroundPixmap (GDK_WINDOW_XDISPLAY (window),
+                                   GDK_WINDOW_XID (window), None);
+       return;


### PR DESCRIPTION
I came up with this patch which should be a lot more reliable than the previous one and good enough to be included in the AUR for now. I'll take it upstream and work with them to see how it can be cleaned up and merged.