### PR TITLE
Relax RGBA visual rules for windows

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -71,7 +71,7 @@ source=(
 	settings.ini
 	"gtk-query-immodules-3.0.hook::https://raw.githubusercontent.com/archlinux/svntogit-packages/$__arch_pkg_commit/trunk/gtk-query-immodules-3.0.hook"
 )
-sha256sums=('6eecb2630d342327c79e7657e1707f7116c5300e862b716e4f4e0e943be3b966'
+sha256sums=('b8985a8fa59ba77ee348dca6a79b9198859ddce8193fbde209b95c2ba8553ee1'
             '6de32e1bee6bf4307aaec072fc8431b044e73299720a490298b8c1b7c502e039'
             'c8f6be1df687bf2ccaaeff63fffdc13e2c1d41f89ad1dfa391120c509dba7f33'
             '760bd3d65b3c5c0be19311d3b9d2be1f33c3bec198bc470de5afe23f5d488b8f'
@@ -95,6 +95,7 @@ sha256sums=('6eecb2630d342327c79e7657e1707f7116c5300e862b716e4f4e0e943be3b966'
             'af2d2d4a0d876f9abc350a1cdb09ffc016a8894ee3c46030c3d90c6e99b27c5a'
             '0dee47c1e4185aef0b436ccd3f383d2e97ab0e6f0095caccded4ec0d2ac3402d'
             '8817a2640cb776eb4e8994d9f11fb4e091875bbf4f1a9de5745191ef210e145e'
+            '20a12a31a85d6c115402c3c0d307c77c0bc7f1492e1f38b0070c9872df31e9f4'
             'ba93f62e249f2713dbfe6c82de1be4ac655264d6407ed3dc5e05323027520f31'
             'ba75bfff320ad1f4cfbee92ba813ec336322cc3c660d406aad014b07087a3ba9'
             '01fc1d81dc82c4a052ac6e25bf9a04e7647267cc3017bc91f9ce3e63e5eb9202'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -59,6 +59,7 @@ source=(
 	popovers__places-sidebar.patch
 	notebook_wheel_scroll.patch
 	treeview__alternating_row_colours.patch
+	window__rgba-visual.patch
 
 	# Theme CSS stylesheet.
 	smaller-adwaita.css

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ To restore the original gtk+3.0 packages from Ubuntu's repository:
 * Labels are wrapped similarly to GTK2. This patch fixes too wide windows in applications improperly ported from GTK2.
 * Errors in console output caused by integration with Accessibility Toolkit are hidden.
   * See https://unix.stackexchange.com/questions/230238.
-
+* Allows windows to be transparent whenever a compositor is enabled.
+  * See https://gitlab.gnome.org/GNOME/gtk/-/issues/3105
 
 ## Problems?
 

--- a/series
+++ b/series
@@ -21,3 +21,4 @@ popovers__file-chooser-list.patch
 popovers__places-sidebar.patch
 notebook_wheel_scroll.patch
 treeview__alternating_row_colours.patch
+window__rgba-visual.patch

--- a/window__rgba-visual.patch
+++ b/window__rgba-visual.patch
@@ -1,0 +1,39 @@
+Index: gtk+-3.24.30/gtk/gtkwindow.c
+===================================================================
+--- gtk+-3.24.30.orig/gtk/gtkwindow.c
++++ gtk+-3.24.30/gtk/gtkwindow.c
+@@ -4149,15 +4149,10 @@ gtk_window_enable_csd (GtkWindow *window
+ {
+   GtkWindowPrivate *priv = window->priv;
+   GtkWidget *widget = GTK_WIDGET (window);
+-  GdkVisual *visual;
+ 
+   /* We need a visual with alpha for client shadows */
+   if (priv->use_client_shadow)
+     {
+-      visual = gdk_screen_get_rgba_visual (gtk_widget_get_screen (widget));
+-      if (visual != NULL)
+-        gtk_widget_set_visual (widget, visual);
+-
+       gtk_style_context_add_class (gtk_widget_get_style_context (widget), GTK_STYLE_CLASS_CSD);
+     }
+   else
+@@ -7371,10 +7366,18 @@ gtk_window_realize (GtkWidget *widget)
+   GtkWindowPrivate *priv;
+   gint i;
+   GList *link;
++  GdkScreen *screen;
++  GdkVisual *visual;
+ 
+   window = GTK_WINDOW (widget);
+   priv = window->priv;
+ 
++  screen = gtk_widget_get_screen (widget);
++  visual = gdk_screen_get_rgba_visual (screen);
++
++  if (gdk_screen_is_composited (screen) && visual != NULL)
++    gtk_widget_set_visual (widget, visual);
++
+   if (!priv->client_decorated && gtk_window_should_use_csd (window))
+     create_decoration (widget);
+ 


### PR DESCRIPTION
## Contents

This patch relaxes the conditions in which GTK uses the RGBA visual (i.e. enables transparency) for windows. Upstream GTK3 requires that the screen must be composited, the window manager must support `_GTK_FRAME_EXTENTS`, and the window uses CSD (client side decorations) before enabling transparency. This patch drops the latter two requirements and uses the RGBA visual for all windows so long as the screen is composited. 

For more details, see this [issue](https://gitlab.gnome.org/GNOME/gtk/-/issues/3105) and corresponding [merge request](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/2509) in the upstream GTK3 repo; the patch introduced in this PR is equivalent to the changes introduced in the upstream merge request, which was closed due to a lack of interest from the GTK maintainers. 

I hope this is the right place for this patch; if not, feel free to close the pull request (and potentially suggest a better home for it).

## TODO

- [x] ~~I have no experience with PKGBUILDs, so this PR may require additional changes before it can be merged -- I have added the new `.patch` to the `sources` list, but some other things (such as the `sha256sums`) may require updating. The patch works correctly, but I have not tested the PKGBUILD.~~ EDIT: checksums updated (thanks [Arch Wiki](https://wiki.archlinux.org/title/Makepkg#Generate_new_checksums)!), hopefully the GitHub Action will catch any other issues.
- [ ] My limited research into the problem the patch aims to fix (mostly sourced from the linked issue) leads me to believe that the patch was not upstreamed due to CSD-related issues with `_GTK_FRAME_EXTENDS`. Perhaps we should gate the changes in this patch with a `GTK_CSD` environment variable check? So far, I have no idea what the actual problem is however (and hence no good way to test it).
- [x] I can also push a commit adding a brief description of this patch to the README, if deemed necessary.