### PR TITLE
Added special patch to fix FTBFS of Gtk on Focal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This package does not include examples or tests.
 
 If you've previously installed `gtk3-mushrooms`, switch to this new package.
 
-### Ubuntu 19.10
+### Ubuntu 21.10
 
 These packages override the original gtk+3.0 packages of the same name,
 with the version suffixed with `~classic`.

--- a/build-Don-t-export-GResource-related-symbols-with-newer-G.patch
+++ b/build-Don-t-export-GResource-related-symbols-with-newer-G.patch
@@ -1,0 +1,61 @@
+From: Simon McVittie <smcv@debian.org>
+Date: Thu, 9 Jul 2020 16:57:42 +0100
+Subject: build: Don't export GResource-related symbols with newer GLib
+
+This makes the desired behaviour explicit, and matches the behaviour
+seen with Meson, where "external : false" is the default.
+
+Before GNOME/glib!1468, not passing --internal to the resource compiler
+meant "no special export attribute, do what you would normally do",
+so these symbols were not exported due to our global use of
+-fvisibility=hidden.
+
+However, since GNOME/glib!1468, not passing --internal to the resource
+compiler results in the symbols being decorated with G_MODULE_EXPORT,
+which overrides -fvisibility=hidden. This was necessary because Windows
+DLLs normally behave a bit like the equivalent of ELF libraries with
+-fvisibility=hidden.
+
+Signed-off-by: Simon McVittie <smcv@debian.org>
+Bug: https://gitlab.gnome.org/GNOME/gtk/-/issues/2919
+Forwarded: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/2218
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=964679
+---
+ gdk/Makefile.am | 4 ++--
+ gtk/Makefile.am | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/gdk/Makefile.am b/gdk/Makefile.am
+index 3635864..3f915b6 100644
+--- a/gdk/Makefile.am
++++ b/gdk/Makefile.am
+@@ -491,10 +491,10 @@ resource_files = $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --gener
+ 
+ gdkresources.h: gdk.gresource.xml
+ 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) $< --target=$@ \
+-		--sourcedir=$(srcdir) --c-name _gdk --generate-header --manual-register
++		--sourcedir=$(srcdir) --c-name _gdk --generate-header --manual-register --internal
+ gdkresources.c: gdk.gresource.xml $(resource_files)
+ 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) $< --target=$@ \
+-		--sourcedir=$(srcdir) --c-name _gdk --generate-source --manual-register
++		--sourcedir=$(srcdir) --c-name _gdk --generate-source --manual-register --internal
+ 
+ # ------------------- MSVC Build Items ----------------
+ MSVCPROJS = gdk-3
+diff --git a/gtk/Makefile.am b/gtk/Makefile.am
+index 9559595..c703024 100644
+--- a/gtk/Makefile.am
++++ b/gtk/Makefile.am
+@@ -1421,10 +1421,10 @@ resource_files = $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --gener
+ 
+ gtkresources.h: gtk.gresource.xml
+ 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) $< \
+-		--target=$@ --sourcedir=$(srcdir) --c-name _gtk --generate-header --manual-register
++		--target=$@ --sourcedir=$(srcdir) --c-name _gtk --generate-header --manual-register --internal
+ gtkresources.c: gtk.gresource.xml $(resource_files)
+ 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) $< \
+-		--target=$@ --sourcedir=$(srcdir) --c-name _gtk --generate-source --manual-register
++		--target=$@ --sourcedir=$(srcdir) --c-name _gtk --generate-source --manual-register --internal
+ 
+ gtkprivatetypebuiltins.h: stamp-gtkprivatetypebuiltins.h
+ 	@true

--- a/scripts/create-ubuntu-package.sh
+++ b/scripts/create-ubuntu-package.sh
@@ -70,6 +70,9 @@ function skip_patch() {
 
 skip_patch "message-dialog-restore-traditional-look-on-unity.patch"
 skip_patch "unity-border-radius.patch"
+if [ ! "$CODENAME" == "focal" ]; then
+    skip_patch "build-Don-t-export-GResource-related-symbols-with-newer-G.patch"
+fi
 
 # Refresh each patch in sequence to avoid "fuzzy" diffs that would fail later
 export QUILT_PATCHES="debian/patches"

--- a/series
+++ b/series
@@ -21,3 +21,4 @@ popovers__file-chooser-list.patch
 popovers__places-sidebar.patch
 notebook_wheel_scroll.patch
 treeview__alternating_row_colours.patch
+build-Don-t-export-GResource-related-symbols-with-newer-G.patch


### PR DESCRIPTION
Details: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=964679 ; https://salsa.debian.org/gnome-team/gtk3/-/commit/df6191ce8af70e94235b96cc8a513c0a65a51b63 .

You did all steps correctly. 
We simply just discovered FTBFS, I reported it to LaunchPad as https://bugs.launchpad.net/bugs/1956388 .
Test packages are located at https://launchpad.net/~nrbrtx/+archive/ubuntu/gtk3-classic-test .
Thanks! 
I think that puzzle is now solved.

It needs some testing and adjusting. Window borders look good. But right-mouse-click context menu is not shown on GtkFileChooserDialogs. I do not know why.