### PR TITLE
Allow to set outline visible on app start

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -40,6 +40,7 @@ source=(
 	appearance__disable-backdrop.patch
 	appearance__file-chooser.patch
 	appearance__fix_black_border.patch
+	appearance__focus-visible.patch
 	appearance__message-dialogs.patch
 	appearance__print-dialog.patch
 	appearance__smaller-statusbar.patch
@@ -71,11 +72,12 @@ source=(
 	settings.ini
 	"gtk-query-immodules-3.0.hook::https://raw.githubusercontent.com/archlinux/svntogit-packages/$__arch_pkg_commit/trunk/gtk-query-immodules-3.0.hook"
 )
-sha256sums=('b8985a8fa59ba77ee348dca6a79b9198859ddce8193fbde209b95c2ba8553ee1'
+sha256sums=('a1b8556a4972212aeb3c0bd02750c783ecb578a30fd623eba6e575605838be67'
             '6de32e1bee6bf4307aaec072fc8431b044e73299720a490298b8c1b7c502e039'
             '9785368d56b851e52de00eec852fc56f636dbc66d53c74d9b102e7c060f69533'
             '760bd3d65b3c5c0be19311d3b9d2be1f33c3bec198bc470de5afe23f5d488b8f'
             '736821182ac014617006e9d00fafa807a19611f3a9032133dee91b4656b7980a'
+            '35443c1e136af06592aefcfad7e6d69e80f2cd49986b0bb66660558b6190de07'
             '00927690718c65f6b3c025e2e919028f41cd522c573964dd7fdc31b3022b983f'
             'db82bc4647eda7cc102590d5cfffd8524cf126a704358096e0e66f5c068fe46f'
             '24217b43a7ca5bd46ff205b8f2a7c5a5192cafc36f5093255ed9053e5496afed'

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ To restore the original GTK3, use `ppa-purge` to restore the packages from Ubunt
   * You can restore backdrop state by setting `GTK_CSD=1` or `GTK_BACKDROP=1` environment variable.
 * Status bars are smaller regardless of used theme.
 * File chooser dialog, places sidebar and color chooser dialog use a traditional context menu instead of popover.
+* Outline for focused buttons can be enabled on application start by setting `GTK_FOCUS_VISIBLE=1` environment variable.
 
 #### Default Settings
 

--- a/appearance__focus-visible.patch
+++ b/appearance__focus-visible.patch
@@ -1,0 +1,15 @@
+Index: b/gtk/gtkwindow.c
+===================================================================
+--- a/gtk/gtkwindow.c	2020-06-11 04:45:39.000000000 +0200
++++ b/gtk/gtkwindow.c	2022-02-01 18:48:41.921469296 +0100
+@@ -6357,7 +6357,9 @@
+   /* inherit from transient parent, so that a dialog that is
+    * opened via keynav shows focus initially
+    */
+-  if (priv->transient_parent)
++  if (g_strcmp0 (g_getenv ("GTK_FOCUS_VISIBLE"), "1") == 0)
++    gtk_window_set_focus_visible (window, TRUE);
++  else if (priv->transient_parent)
+     gtk_window_set_focus_visible (window, gtk_window_get_focus_visible (priv->transient_parent));
+   else
+     gtk_window_set_focus_visible (window, FALSE);

--- a/series
+++ b/series
@@ -2,6 +2,7 @@ appearance__buttons-menus-icons.patch
 appearance__disable-backdrop.patch
 appearance__file-chooser.patch
 appearance__fix_black_border.patch
+appearance__focus-visible.patch
 appearance__message-dialogs.patch
 appearance__print-dialog.patch
 appearance__smaller-statusbar.patch


### PR DESCRIPTION
This allow to set focus visible (`outline`) on application start by setting `GTK_FOCUS_VISIBLE=1` env variable.