### PR TITLE
README: Fix the Gentoo setup steps to append to a config file, not overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To install, first add the overlay and accept the package's testing status:
 
     sudo eselect repository enable khoverlay
     sudo emerge --sync khoverlay
-    echo 'x11-libs/gtk3-classic-patches::khoverlay' | sudo tee /etc/portage/package.accept_keywords
+    echo 'x11-libs/gtk3-classic-patches::khoverlay' | sudo tee -a /etc/portage/package.accept_keywords
 
 Then install the patches and rebuild GTK3:
 


### PR DESCRIPTION
Hello!  My apologies, I made a typo when writing the Gentoo instructions, and appending to package.accept_keywords with `tee` definitely needs to be with `-a` so that the existing file contents aren't overwritten.