### PR TITLE
add patch to optionally disable printing support

### DIFF
--- a/disable-print.patch
+++ b/disable-print.patch
@@ -1,0 +1,17 @@
+diff --git a/modules/printbackends/meson.build b/modules/printbackends/meson.build
+index f034963..47b5adf 100644
+--- a/modules/printbackends/meson.build
++++ b/modules/printbackends/meson.build
+@@ -34,11 +34,7 @@ endif
+ 
+ print_backends = []
+ 
+-if not enabled_print_backends.contains('file')
+-  if os_unix
+-    error('\'file\' print backed needs to be enabled')
+-  endif
+-else
++if enabled_print_backends.contains('file')
+   print_backends += ['file']
+ endif
+ 


### PR DESCRIPTION
Maybe you or someone else finds this patch interesting/useful.
It adds a build-time option to disable the file printing backend to fully(in some regard) disable printing support.
The patch only affects the build system. No code is actually changed.
With this patch, the printing dialog still shows up when using ctrl+p, but there are to printing backends to chose from.

Also, maybe you can find a better name for the patch.