### PR TITLE
Add patch to remember location mode in file chooser

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -108,6 +108,7 @@ source=(
 	csd__server-side-shadow.patch
 	file-chooser__eject-button.patch
 	file-chooser__places-sidebar.patch
+	file-chooser__remember-location-mode.patch
 	file-chooser__typeahead.patch
 	fixes__labels-wrapping.patch
 	fixes__primary_selection.patch
@@ -137,7 +138,7 @@ source=(
 	settings.ini
 	"gtk-query-immodules-3.0.hook::https://gitlab.archlinux.org/archlinux/packaging/packages/gtk3/-/raw/$__arch_pkg_commit/gtk-query-immodules-3.0.hook"
 )
-sha256sums=('ecbf69e66a073cbcf23454ae1ab366beedae6e96582975ae55964b0cc7bab685'
+sha256sums=('2d0a07b6ecb8fc1a80094792e3c868f93336a8a16face97eca81809a99409d1a'
             '5723d1d2c0e69ce2e7f36973560a2297f6288e1fdfa4f6946104347080c7fc8c'
             '9785368d56b851e52de00eec852fc56f636dbc66d53c74d9b102e7c060f69533'
             '760bd3d65b3c5c0be19311d3b9d2be1f33c3bec198bc470de5afe23f5d488b8f'
@@ -150,6 +151,7 @@ sha256sums=('ecbf69e66a073cbcf23454ae1ab366beedae6e96582975ae55964b0cc7bab685'
             'cf26ab623fec6fc4f24628bdbe4b81ba5f56e8e0c61de78474d5c2411901931a'
             'ffd9112691b890e263e3eafec71c9838e215c41e6dfd4750e1a498332afbf8f4'
             '6f5cfa1f3d0b1bd426e2be738b371f1910674dba8c67f4cb3de20bd55e15879e'
+            'a23dfeb7ee3de606af88383ef9a36e0053edf9193086e73860ae7bbcafbb9f42'
             'c6fd146e7ab332dd9a394b666b19e6ba7d6ac0932f33fb396f66630134257309'
             '7157b665e2ae724bb6abe8fc382d7178dc4d8d00f29bc63ed2942307ff41914b'
             '135defcbaa4832ae09c79d39231f327c1399159c1a7520c2ebfd2ca5d7fc9a7b'

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ To revert to standard GTK 3, remove the patches and rebuild GTK 3:
   * These can be added as bookmarks.
 * File System button in Places sidebar is labeled as "File System" instead of "Computer".
 * The eject button in the Places sidebar can be hidden by setting `gtk-file-chooser-eject-button=false` in `settings.ini`.
+* Remembers location field setting (text entry or path bar). See https://gitlab.gnome.org/GNOME/gtk/issues/6471.
 
 #### Appearance
 

--- a/file-chooser__remember-location-mode.patch
+++ b/file-chooser__remember-location-mode.patch
@@ -1,0 +1,13 @@
+Index: gtk-3.24.49/gtk/gtkfilechooserwidget.c
+===================================================================
+--- gtk-3.24.49.orig/gtk/gtkfilechooserwidget.c
++++ gtk-3.24.49/gtk/gtkfilechooserwidget.c
+@@ -3934,6 +3934,8 @@ settings_load (GtkFileChooserWidget *imp
+   sort_directories_first = g_settings_get_boolean (settings, SETTINGS_KEY_SORT_DIRECTORIES_FIRST);
+   date_format = g_settings_get_enum (settings, SETTINGS_KEY_DATE_FORMAT);
+   type_format = g_settings_get_enum (settings, SETTINGS_KEY_TYPE_FORMAT);
++  priv->location_mode = g_settings_get_enum (settings, SETTINGS_KEY_LOCATION_MODE);
++  location_mode_set (impl, priv->location_mode);
+ 
+   if (!priv->show_hidden_set)
+     set_show_hidden (impl, show_hidden);

--- a/series
+++ b/series
@@ -10,6 +10,7 @@ csd__disabled-by-default.patch
 csd__server-side-shadow.patch
 file-chooser__eject-button.patch
 file-chooser__places-sidebar.patch
+file-chooser__remember-location-mode.patch
 file-chooser__typeahead.patch
 fixes__labels-wrapping.patch
 #fixes__too-large-menu-covers-bar.patch


### PR DESCRIPTION
Ensures the mode of the location bar in the file chooser is remembered (path or text) between sessions.

Fixes https://gitlab.gnome.org/GNOME/gtk/-/issues/6471
Fixes #123